### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "lucide-react": "^0.503.0",
         "next": "^15.5.21",
         "object-hash": "^3.0.0",
-        "postcss": "^8.5.10",
+        "postcss": "^8.5.18",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "sharp": "^0.35.0",
@@ -4458,9 +4458,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8433,9 +8433,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -8889,9 +8889,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",
@@ -9525,9 +9525,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "funding": [
         {
           "type": "opencollective",
@@ -9544,7 +9544,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -6207,9 +6207,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -34,19 +34,20 @@
     "object-hash": "^3.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "postcss": "^8.5.10",
+    "postcss": "^8.5.18",
     "sharp": "^0.35.0",
     "uuid": "^11.1.1"
   },
   "overrides": {
     "protobufjs": "^7.6.5",
     "minimatch": "^3.1.3",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.3.0",
     "diff": "^5.2.0",
     "yaml": "^2.8.3",
     "postcss": "$postcss",
     "fast-uri": ">=3.1.4 <4",
     "sharp": "$sharp",
+    "brace-expansion": ">=1.1.16 <2",
     "@opentelemetry/core": "^2.8.0",
     "@opentelemetry/resources": "^2.8.0"
   },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "diff": "^5.2.0",
     "yaml": "^2.8.3",
     "postcss": "$postcss",
-    "fast-uri": ">=3.1.4 <4",
+    "fast-uri": ">=3.1.5 <4",
     "sharp": "$sharp",
     "brace-expansion": ">=1.1.16 <2",
     "@opentelemetry/core": "^2.8.0",


### PR DESCRIPTION
## Summary

- Resolved 4 open Dependabot security alerts by bumping vulnerable dependencies

## Dependabot Alerts Resolved

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #122 | `fast-uri` | **high** | Bumped existing `overrides` entry from `>=3.1.4 <4` to `>=3.1.5 <4` (patched) |
| #120 | `postcss` | **high** | Bumped direct dependency to `^8.5.18` (patched); existing `$postcss` override propagates the fix to nested resolutions |
| #119 | `js-yaml` | **high** | Bumped existing `overrides` entry from `^4.1.1` to `^4.3.0` |
| #118 | `brace-expansion` | **high** | Added new `overrides` entry `>=1.1.16 <2` (transitive dependency, only the 1.x line is in use) |

`npm test` and `npm run build` pass on the updated lockfile.